### PR TITLE
031/eric/builtin/fixandsetup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 minishell
 tmp_fd
 obj/
+.vscode/*
+settings.json

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@
 
 NAME		= 	minishell
 CC			=	cc
-CFLAGS		=	-Wall -Wextra -Werror -Iinclude -I$(LIBFT_DIR) -MMD -MP
-LDFLAGS		=	-lreadline -ltermcap -lncurses
+CFLAGS		=	-Wall -Wextra -Werror -Iinclude -I$(LIBFT_DIR) -MMD -MP -I$(shell brew --prefix readline)/include
+LDFLAGS		=	-lreadline -ltermcap -lncurses -L$(shell brew --prefix readline)/lib
 
 RM			=	/bin/rm -f
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: erpascua <erpascua@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/30 14:31:03 by erpascua          #+#    #+#             */
-/*   Updated: 2025/09/12 16:11:19 by erpascua         ###   ########.fr       */
+/*   Updated: 2025/09/16 07:11:58 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,11 +16,11 @@
 # include "libft.h"
 # include <errno.h>
 # include <fcntl.h>
+# include <stdio.h>
 # include <readline/history.h>
 # include <readline/readline.h>
 # include <signal.h>
 # include <stdbool.h>
-# include <stdio.h>
 # include <string.h>
 # include <term.h>
 
@@ -90,7 +90,7 @@ typedef struct s_msh
 	bool			is_heredoc;
 	bool			is_builtin;
 	char			*builtin_names[NB_BUILTINS];
-	int				(*builtin_funcs[NB_BUILTINS])(void);
+	int				(*builtin_funcs[NB_BUILTINS])(char **);
 }					t_msh;
 
 int					launch_program(t_msh *msh);
@@ -136,13 +136,13 @@ void				classify_single_token(t_stack *tmp);
 int					parse(t_msh *msh);
 // BUILT-IN
 bool				is_builtin(t_msh *msh);
-int					bi_exit(void);
-int					bi_echo(char *s);
-int					bi_cd(void);
-int					bi_pwd(void);
-int					bi_export(void);
-int					bi_unset(void);
-int					bi_env(void);
+int					bi_exit(char **argv);
+int					bi_echo(char **argv);
+int					bi_cd(char **argv);
+int					bi_pwd(char **argv);
+int					bi_export(char **argv);
+int					bi_unset(char **argv);
+int					bi_env(char **argv);
 // SIGNALS
 bool				is_eof(void);
 void				sigint_handler(int process);

--- a/src/built-in/cd.c
+++ b/src/built-in/cd.c
@@ -3,17 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   cd.c                                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: erpascua <erpascua@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/13 19:02:29 by erpascua          #+#    #+#             */
-/*   Updated: 2025/08/13 19:03:43 by erpascua         ###   ########.fr       */
+/*   Updated: 2025/09/16 07:52:53 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	bi_cd(void)
+int	bi_cd(char **argv)
 {
+	(void)argv;
 	ft_putendl_fd("cd", 1);
 	return (0);
 }

--- a/src/built-in/echo.c
+++ b/src/built-in/echo.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   echo.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: erpascua <erpascua@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/13 19:01:32 by erpascua          #+#    #+#             */
-/*   Updated: 2025/09/12 20:15:37 by erpascua         ###   ########.fr       */
+/*   Updated: 2025/09/16 07:34:21 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,13 +16,13 @@ bool	is_flag_n(char *s)
 {
 	int	i;
 
-	if (!s || !s[0] != '-' || s[1] != 'n')
+	if (!s || s[0] != '-' || s[1] != 'n')
 		return (false);
 	i = 2;
 	while (s[i])
 	{
 		if (s[i] != 'n')
-			return (true);
+			return (false);
 		i++;
 	}
 	return (true);
@@ -32,11 +32,9 @@ int	bi_echo(char **argv)
 {
 	int		i;
 	bool	no_newline;
-	bool	is_first;
 
 	i = 1;
 	no_newline = false;
-	is_first = true;
 	while (argv[i] && is_flag_n(argv[i]))
 	{
 		no_newline = true;
@@ -45,12 +43,9 @@ int	bi_echo(char **argv)
 	while (argv[i])
 	{
 		ft_fprintf(1, "%s", argv[i]);
-		if (is_first)
-		{
-			ft_fprintf(1, " ");
-			is_first = false;
-		}
 		i++;
+		if (argv[i])
+			ft_fprintf(1, " ");
 	}
 	if (!no_newline)
 		ft_fprintf(1, "\n");

--- a/src/built-in/env.c
+++ b/src/built-in/env.c
@@ -3,17 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: erpascua <erpascua@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/13 19:06:05 by erpascua          #+#    #+#             */
-/*   Updated: 2025/08/13 19:06:34 by erpascua         ###   ########.fr       */
+/*   Updated: 2025/09/16 07:53:00 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	bi_env(void)
+int	bi_env(char **argv)
 {
+	(void)argv;
 	ft_putendl_fd("env", 1);
 	return (0);
 }

--- a/src/built-in/exit.c
+++ b/src/built-in/exit.c
@@ -12,8 +12,9 @@
 
 #include "minishell.h"
 
-int	bi_exit(void)
+int	bi_exit(char **argv)
 {
+	(void)argv; // Unused parameter
 	ft_putendl_fd("exit", 1);
 	return (0);
 }

--- a/src/built-in/export.c
+++ b/src/built-in/export.c
@@ -3,17 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: erpascua <erpascua@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/13 19:04:02 by erpascua          #+#    #+#             */
-/*   Updated: 2025/08/13 19:04:14 by erpascua         ###   ########.fr       */
+/*   Updated: 2025/09/16 07:52:12 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	bi_export(void)
+int	bi_export(char **argv)
 {
+	(void)argv;
 	ft_putendl_fd("export", 1);
 	return (0);
 }

--- a/src/built-in/is_builtin.c
+++ b/src/built-in/is_builtin.c
@@ -14,19 +14,25 @@
 
 bool	is_builtin(t_msh *msh)
 {
-	int	i;
+	int		i;
+	char	**argv;
 
 	i = 0;
+	argv = split_spaces(msh->entry);
+	if (!argv || !argv[0])
+		return (0);
 	while (i < NB_BUILTINS)
 	{
-		if (!ft_strncmp(msh->builtin_names[i], msh->entry, ft_strlen(msh->entry)
-				+ 1))
+		if (!ft_strncmp(msh->builtin_names[i], argv[0], ft_strlen(msh->builtin_names[i]) + 1))
 		{
-			msh->builtin_funcs[i]();
+			msh->builtin_funcs[i](argv);
+			free_tab(argv);
 			msh->is_builtin = 1;
 			return (1);
 		}
 		i++;
 	}
+	free_tab(argv);
+	msh->is_builtin = 0;
 	return (0);
 }

--- a/src/built-in/pwd.c
+++ b/src/built-in/pwd.c
@@ -3,20 +3,21 @@
 /*                                                        :::      ::::::::   */
 /*   pwd.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: erpascua <erpascua@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/13 19:02:46 by erpascua          #+#    #+#             */
-/*   Updated: 2025/09/12 14:56:11 by erpascua         ###   ########.fr       */
+/*   Updated: 2025/09/16 07:15:57 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	bi_pwd(void)
+int	bi_pwd(char **argv)
 {
 	int		i;
 	char	*buf;
 
+	(void)argv;
 	i = 1;
 	buf = malloc(i);
 	while (getcwd(buf, i) == NULL && errno == ERANGE)

--- a/src/built-in/unset.c
+++ b/src/built-in/unset.c
@@ -3,17 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   unset.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: erpascua <erpascua@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/13 19:05:40 by erpascua          #+#    #+#             */
-/*   Updated: 2025/08/13 19:05:48 by erpascua         ###   ########.fr       */
+/*   Updated: 2025/09/16 07:15:54 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	bi_unset(void)
+int	bi_unset(char **argv)
 {
+	(void)argv;
 	ft_putendl_fd("unset", 1);
 	return (0);
 }

--- a/src/exec/launch_program.c
+++ b/src/exec/launch_program.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   launch_program.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gpollast <gpollast@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/11 18:37:31 by erpascua          #+#    #+#             */
-/*   Updated: 2025/09/01 13:14:43 by gpollast         ###   ########.fr       */
+/*   Updated: 2025/09/16 07:47:19 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,9 +21,6 @@ void	update_history(t_msh *msh)
 
 static int	repl(t_msh *msh, int tmp_fd)
 {
-	int	process;
-
-	process = getpid();
 	signal(SIGQUIT, SIG_IGN);
 	signal(SIGINT, sigint_handler);
 	while (1)

--- a/src/signals/sig_int.c
+++ b/src/signals/sig_int.c
@@ -3,14 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   sig_int.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: erpascua <erpascua@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/15 15:21:44 by erpascua          #+#    #+#             */
-/*   Updated: 2025/08/19 19:25:14 by erpascua         ###   ########.fr       */
+/*   Updated: 2025/09/16 06:42:21 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+#include <readline/history.h>
+#include <readline/readline.h>
 
 void	sigint_handler(int signum)
 {


### PR DESCRIPTION
### #31 Setup des builtins
 

- [x] Bugs fixés pour `readline` sous MacOS.
- [x] Modification de tous les paramètres des fonctions Builtins en `Char **`.
- [x] Correction du builtin `echo` pour gérer les cas invalides avec `-n`.
- [x] Adaptation de la fonction `is_builtin()` afin qu'elle détecte les `char **`. 