### PR TITLE
(feat): Unset - Remove element from lst msh->env

### DIFF
--- a/src/built-in/unset.c
+++ b/src/built-in/unset.c
@@ -3,19 +3,61 @@
 /*                                                        :::      ::::::::   */
 /*   unset.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
+/*   By: erpascua <erpascua@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/13 19:05:40 by erpascua          #+#    #+#             */
-/*   Updated: 2025/09/17 02:47:53 by ep               ###   ########.fr       */
+/*   Updated: 2025/09/17 19:11:32 by erpascua         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+static void	unset_first_node(t_msh *msh, t_env *node)
+{
+	msh->env = node->next;
+	free(node->key);
+	free(node->value);
+	free(node);
+}
+
+static void	unset_middle_node(t_env *prev, t_env *node)
+{
+	prev->next = node->next;
+	free(node->key);
+	free(node->value);
+	free(node);
+}
+
+static void	unset_variable(t_msh *msh, char *var_name)
+{
+	t_env	*tmp;
+
+	tmp = msh->env;
+	if (tmp && ft_strncmp(var_name, tmp->key, ft_strlen(var_name) + 1) == 0)
+	{
+		unset_first_node(msh, tmp);
+		return ;
+	}
+	while (tmp && tmp->next)
+	{
+		if (ft_strncmp(var_name, tmp->next->key, ft_strlen(var_name) + 1) == 0)
+		{
+			unset_middle_node(tmp, tmp->next);
+			break ;
+		}
+		tmp = tmp->next;
+	}
+}
+
 int	bi_unset(t_msh *msh, char **av)
 {
-	(void)msh;
-	(void)av;
-	ft_putendl_fd("unset", 1);
+	int	i;
+
+	i = 1;
+	while (av[i])
+	{
+		unset_variable(msh, av[i]);
+		i++;
+	}
 	return (0);
 }


### PR DESCRIPTION
### #15 unset

- [ ] Pour chaque nom :
> - [ ]         Valider l’identifiant : regex 42 classique [A-Za-z_][A-Za-z0-9_]*.
> - [ ]         Si invalide : erreur minishell: unset: \NAME': not a valid identifieret **cumul** d’un status global à1`.
> - [x]         Si valide : supprimer la clé si présente ; pas de message si absente.
- [x]     Toujours en parent (modifie l’état du shell).
- [ ]     Retour : 0 si tout valide ; 1 s’il y a eu au moins un identifiant invalide.
- [x]     Tests : 
> - [x] unset FOO, 
> - [x] unset 1X a-b, 
> - [x] vérifie que env ne montre plus la clé.
