### PR TITLE
(feat): CD - New struct created and cd with all treatments created

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/30 14:31:03 by erpascua          #+#    #+#             */
-/*   Updated: 2025/09/17 02:29:39 by ep               ###   ########.fr       */
+/*   Updated: 2025/09/19 07:04:14 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,13 +16,13 @@
 # include "libft.h"
 # include <errno.h>
 # include <fcntl.h>
-# include <signal.h>
-# include <stdbool.h>
 # include <stdio.h>
-# include <string.h>
-# include <term.h>
 # include <readline/history.h>
 # include <readline/readline.h>
+# include <signal.h>
+# include <stdbool.h>
+# include <string.h>
+# include <term.h>
 
 extern int				g_exit_code;
 
@@ -80,6 +80,15 @@ typedef struct s_cmd
 	struct s_cmd		*next;
 }						t_cmd;
 
+typedef struct t_paths
+{
+	char				*pwd;
+	char				*oldpwd;
+	char				*home;
+	bool				has_home;
+	bool				has_oldpwd;
+}						t_paths;
+
 typedef struct s_msh	t_msh;
 
 typedef struct s_msh
@@ -93,6 +102,7 @@ typedef struct s_msh
 	bool				is_builtin;
 	char				*builtin_names[NB_BUILTINS];
 	int					(*builtin_funcs[NB_BUILTINS])(t_msh *, char **);
+	t_paths				paths;
 }						t_msh;
 
 int						launch_program(t_msh *msh);
@@ -142,6 +152,11 @@ bool					is_builtin(t_msh *msh);
 int						bi_exit(t_msh *msh, char **argv);
 int						bi_echo(t_msh *msh, char **argv);
 int						bi_cd(t_msh *msh, char **argv);
+bool					cd_home(t_env *env, t_paths *paths);
+bool					cd_oldpwd(t_env *env, t_paths *paths);
+bool					cd_folder(t_env *env, t_paths *paths, char *folder);
+void					cd_get_paths(t_env *env, t_paths *paths);
+void					cd_update_env(t_env *env, t_paths *paths);
 int						bi_pwd(t_msh *msh, char **argv);
 int						bi_export(t_msh *msh, char **argv);
 int						bi_unset(t_msh *msh, char **argv);

--- a/src/built-in/cd.c
+++ b/src/built-in/cd.c
@@ -6,16 +6,85 @@
 /*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/13 19:02:29 by erpascua          #+#    #+#             */
-/*   Updated: 2025/09/17 02:30:23 by ep               ###   ########.fr       */
+/*   Updated: 2025/09/19 07:00:49 by ep               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+void	cd_get_paths(t_env *env, t_paths *paths)
+{
+	t_env	*tmp;
+
+	tmp = env;
+	paths->has_home = false;
+	paths->has_oldpwd = false;
+	paths->pwd = NULL;
+	paths->oldpwd = NULL;
+	paths->home = NULL;
+	while (tmp)
+	{
+		if (strncmp(tmp->key, "PWD", 4) == 0 && tmp->key[3] == '\0')
+			paths->pwd = ft_strdup(tmp->value);
+		if (strncmp(tmp->key, "OLDPWD", 7) == 0 && tmp->key[6] == '\0')
+		{
+			paths->oldpwd = ft_strdup(tmp->value);
+			paths->has_oldpwd = true;
+		}
+		if (strncmp(tmp->key, "HOME", 5) == 0 && tmp->key[4] == '\0')
+		{
+			paths->home = ft_strdup(tmp->value);
+			paths->has_home = true;
+		}
+		tmp = tmp->next;
+	}
+}
+
+void	cd_update_env(t_env *env, t_paths *paths)
+{
+	t_env	*tmp;
+
+	tmp = env;
+	while (tmp)
+	{
+		if (strncmp(tmp->key, "PWD", 4) == 0 && tmp->key[3] == '\0')
+		{
+			free(paths->oldpwd);
+			paths->oldpwd = ft_strdup(tmp->value);
+			free(tmp->value);
+			tmp->value = ft_strdup(paths->pwd);
+		}
+		if (strncmp(tmp->key, "OLDPWD", 7) == 0 && tmp->key[6] == '\0')
+		{
+			free(tmp->value);
+			tmp->value = ft_strdup(paths->oldpwd);
+		}
+		tmp = tmp->next;
+	}
+}
+
 int	bi_cd(t_msh *msh, char **av)
 {
-	(void)msh;
-	(void)av;
-	ft_putendl_fd("cd", 1);
+	int	i;
+
+	i = 1;
+	while (av[i])
+		i++;
+	if (i > 2)
+	{
+		ft_fprintf(2, "Minishell: cd: too many arguments\n");
+		g_exit_code = 1;
+		return (1);
+	}
+	cd_get_paths(msh->env, &msh->paths);
+	if (i == 1 || (ft_strncmp(av[1], "~", 1) == 0 && av[1][1] == '\0'))
+		cd_home(msh->env, &msh->paths);
+	else if (ft_strncmp(av[1], "-", 1) == 0 && av[1][1] == '\0')
+		cd_oldpwd(msh->env, &msh->paths);
+	else
+		cd_folder(msh->env, &msh->paths, av[1]);
+	free(msh->paths.home);
+	free(msh->paths.pwd);
+	free(msh->paths.oldpwd);
 	return (0);
 }

--- a/src/built-in/cd_utils.c
+++ b/src/built-in/cd_utils.c
@@ -1,0 +1,98 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cd_utils.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ep <ep@student.42.fr>                      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/19 06:45:30 by ep                #+#    #+#             */
+/*   Updated: 2025/09/19 07:06:54 by ep               ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+bool	cd_home(t_env *env, t_paths *paths)
+{
+	if (paths->has_home)
+	{
+		free(paths->pwd);
+		paths->pwd = ft_strdup(paths->home);
+		cd_update_env(env, paths);
+		chdir(paths->pwd);
+	}
+	else
+	{
+		ft_fprintf(1, "minishell: cd: HOME not set\n");
+		g_exit_code = 1;
+		return (false);
+	}
+	return (true);
+}
+
+bool	cd_oldpwd(t_env *env, t_paths *paths)
+{
+	if (paths->has_oldpwd && paths->oldpwd)
+	{
+		free(paths->pwd);
+		paths->pwd = ft_strdup(paths->oldpwd);
+		ft_fprintf(1, "%s\n", paths->pwd);
+		cd_update_env(env, paths);
+		chdir(paths->pwd);
+	}
+	else
+	{
+		ft_fprintf(2, "Minishell: cd: OLDPWD not set\n");
+		g_exit_code = 1;
+		return (false);
+	}
+	return (true);
+}
+
+static char	*unify_path(t_paths *paths, char *folder)
+{
+	char	*slash_folder;
+	char	*target_path;
+	char	*current_dir;
+
+	if (!paths->pwd)
+	{
+		current_dir = getcwd(NULL, 0);
+		if (!current_dir)
+			return (NULL);
+	}
+	else
+		current_dir = paths->pwd;
+	slash_folder = ft_strjoin("/", folder);
+	target_path = ft_strjoin(current_dir, slash_folder);
+	free(slash_folder);
+	if (!paths->pwd)
+		free(current_dir);
+	return (target_path);
+}
+
+bool	cd_folder(t_env *env, t_paths *paths, char *folder)
+{
+	char	*target_path;
+
+	if (folder[0] == '/')
+		target_path = ft_strdup(folder);
+	else
+	{
+		target_path = unify_path(paths, folder);
+		if (!target_path)
+			return (ft_fprintf(2, "cd: error retrieving current directory\n"),
+				g_exit_code = 1, false);
+	}
+	if (chdir(target_path) == 0)
+	{
+		free(paths->pwd);
+		paths->pwd = ft_strdup(target_path);
+		free(target_path);
+		cd_update_env(env, paths);
+		return (true);
+	}
+	else
+		return (ft_fprintf(2, "minishell: cd: %s: No such file or directory\n",
+				folder), free(target_path), g_exit_code = 1, false);
+}


### PR DESCRIPTION
### #17 CD

### cd

> But : changer de dossier et mettre à jour PWD/OLDPWD.

**Implémentation**

- [x]  Cas :
> - [x]         cd (sans arg) → aller à $HOME ; si absent → minishell: cd: HOME not set, retour 1.
> - [x]         cd - → aller à $OLDPWD ; si absent → minishell: cd: OLDPWD not set, **retour 1`; sinon afficher le nouveau chemin.
> - [x]         cd PATH → chdir(PATH) ; en cas d’échec → minishell: cd: PATH: <strerror(errno)>, retour 1.
- [x]     En succès :
> - [x]         Mettre à jour OLDPWD = ancien PWD, puis PWD = getcwd() (robuste).
- [x]     Toujours en parent.
- [x]     Retour : 0 si OK, sinon 1.
- [x]     Tests : 
> - [x] cd, 
> - [x] cd -, 
> - [x] cd /nope, 
> - [x] changements successifs et cohérence pwd.